### PR TITLE
Password feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Once you deploy the nodes, the Admin account password of the nodes need to be ch
 
 This script allows you to change the admin user's password in bulk. You can use this script to change the admin password immediately after the VMN deployment or at any other point.
 
-Edit the `input_password.csv` file to include details of the nodes for which to change the admin account password  (IP, Old Password, New Password).
+Edit the `input_password.csv` file to include details of the nodes for which to change the admin account password  (VMN IP/FQDN, Old Password, New Password).
 
 Leave the Old Password field blank if you’re changing the password for that node for the first time ever (recently deployed nodes).
 
@@ -154,10 +154,11 @@ Leave the Old Password field blank if you’re changing the password for that no
 
 ### **Sample csv:**
 
-| node\_ip | old\_password | new\_password |
-| -------- | ------------- | ------------- |
-| 1.1.1.1  |               | newpass       |
-| 2.2.2.2  | oldpass       | newpass       |
+| node\_ip       | old\_password | new\_password |
+|----------------| ------------- | ------------- |
+| 1.1.1.1        |               | newpass       |
+| hosname.domain |               | newpass       |
+| 2.2.2.2        | oldpass       | newpass       |
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -154,11 +154,11 @@ Leave the Old Password field blank if you’re changing the password for that no
 
 ### **Sample csv:**
 
-| node\_ip       | old\_password | new\_password |
-|----------------| ------------- | ------------- |
-| 1.1.1.1        |               | newpass       |
-| hosname.domain |               | newpass       |
-| 2.2.2.2        | oldpass       | newpass       |
+| video\_mesh\_node | old\_password | new\_password |
+|-------------------| ------------- | ------------- |
+| 1.1.1.1           |               | newpass       |
+| hosname.domain    |               | newpass       |
+| 2.2.2.2           | oldpass       | newpass       |
 
 <br />
 

--- a/input_password.csv
+++ b/input_password.csv
@@ -1,1 +1,1 @@
-node_ip,old_password,new_password
+video_mesh_node,old_password,new_password


### PR DESCRIPTION
Previously, when the admin account password of the video mesh nodes were changed, it required the node IP to be provided as input in the input_password.csv file. 

This feature allows to use to Fully qualified domain name (FQDN) of the node as well as input in the input_password.csv file.

Below is an example of the input file for changing admin password for multiple VMNs

<img width="464" alt="image" src="https://user-images.githubusercontent.com/105696733/178703811-892d9a41-4184-4653-8013-819fae6e4bab.png">


README.md has been updated accordingly for the usage of the script.