### PR TITLE
Removed the deprecated SmartConnectNoSSL

### DIFF
--- a/get_esxi_path_on_vcenter.py
+++ b/get_esxi_path_on_vcenter.py
@@ -2,7 +2,7 @@ from pyVim import connect
 
 
 def get_esxi_entity(vcenter, username, passwd, esxi_name):
-    si = connect.SmartConnectNoSSL(host=vcenter, user=username, pwd=passwd)
+    si = connect.SmartConnect(host=vcenter, user=username, pwd=passwd, disableSslCertValidation=True)
     content = si.RetrieveContent()
 
     host_list = []

--- a/validations/check_esxi.py
+++ b/validations/check_esxi.py
@@ -2,7 +2,7 @@ from pyVim import connect
 
 
 def check_esxi_name(vcenter, username, passwd, esxi_name):
-    si = connect.SmartConnectNoSSL(host=vcenter, user=username, pwd=passwd)
+    si = connect.SmartConnect(host=vcenter, user=username, pwd=passwd, disableSslCertValidation=True)
     content = si.RetrieveContent()
 
     host_list = []

--- a/validations/host_validation.py
+++ b/validations/host_validation.py
@@ -1,7 +1,7 @@
 import csv
 import signal
 from contextlib import contextmanager
-from pyVim.connect import SmartConnectNoSSL
+from pyVim import connect
 
 TIMEOUT = 20
 MESSAGE = f'Could not connect. Timed-out after {TIMEOUT} seconds'
@@ -65,7 +65,7 @@ def host_validation(input_file):
             passwd = next(iter(host_dict[host][user]))
             try:
                 with time_out(TIMEOUT):
-                    si = SmartConnectNoSSL(host=host, user=user, pwd=passwd)
+                    si = connect.SmartConnect(host=host, user=user, pwd=passwd, disableSslCertValidation=True)
                 if si is None:
                     connection_issue.append(host)
                     exit_flag = True


### PR DESCRIPTION
connect.SmartConnectNoSSL has been removed/deprecated as part of the pyvmomi package release.
https://github.com/vmware/pyvmomi/releases/tag/v8.0.0.1

Hence, changed the code to use connect.SmartConnect(disableSslCertValidation=True) instead.